### PR TITLE
改进管理面板左侧导航

### DIFF
--- a/dashboard/views/common/left_nav.html
+++ b/dashboard/views/common/left_nav.html
@@ -101,12 +101,16 @@
             <li class="hidden-folded padder m-t m-b-sm text-muted text-xs">
                 <span class="ng-scope">管理</span>
             </li>
+            {%
+            	if locals.is_admin then
+            %}
             <li id="nav-user-manage">
                 <a href="/admin/user/manage">
                     <i class="fa fa-user"></i>
                     <span class="nav-label">用户管理</span>
                 </a>
             </li>
+            {% end %}
             <li>
                 <a href="/auth/logout">
                     <i class="fa fa-sign-out"></i>


### PR DESCRIPTION
非管理员用户在“管理”项目下不显示“用户管理”