### PR TITLE
remove duplicate route and other else.

### DIFF
--- a/orange/plugins/kvstore/api.lua
+++ b/orange/plugins/kvstore/api.lua
@@ -70,15 +70,6 @@ end
 
 local API = BaseAPI:new("kvstore-api", 2)
 
-API:get("/kvstore/configs", function(store)
-    res:json({
-        success = true, 
-        data = {
-            enable = orange_db.get("kvstore.enable")
-        }
-    })
-end)
-
 API:post("/kvstore/enable", function(store)
     return function(req, res, next)
         local enable = req.body.enable

--- a/orange/store/base.lua
+++ b/orange/store/base.lua
@@ -6,11 +6,11 @@ function Store:new(name)
 end
 
 function Store:set(k, v)
-    ngx.log(ngx.DEBUG, " store \"" .. self._name .. "\" get:" .. k)
+    ngx.log(ngx.DEBUG, " store \"" .. self._name .. "\" set:" .. k, " v:", v)
 end
 
 function Store:get(k)
-    ngx.log(ngx.DEBUG, " store \"" .. self._name .. "\" set:" .. k, " v:", v)
+    ngx.log(ngx.DEBUG, " store \"" .. self._name .. "\" get:" .. k)
 end
 
 return Store


### PR DESCRIPTION
`API:get("/kvstore/configs"` is duplicated with the same route under 
https://github.com/spacewander/orange/blob/f2ba915e5f560d5eb2aefc831ab2c1c1ab839b1c/orange/plugins/kvstore/api.lua#L218
And also switch the log statements under `store/base.lua`.