### PR TITLE
log format && config path  && some others

### DIFF
--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -14,7 +14,9 @@ http {
 
     log_format  main '$remote_addr - $remote_user [$time_local] "$request" '
     '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    '"$http_user_agent" "$request_time" "$ssl_protocol" "$ssl_cipher" "$http_x_forwarded_for"'
+    '"$upstream_addr" "$upstream_status" "$upstream_response_length" "$upstream_response_time"';
+
     access_log  ./logs/access.log  main;
     error_log ./logs/error.log info;
 
@@ -71,6 +73,12 @@ http {
         location = /favicon.ico {
             log_not_found off;
             access_log off;
+        }
+
+        location /gateway_benchmark {
+            content_by_lua_block{
+                ngx.say('work good');
+            }
         }
 
         location / {

--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -47,7 +47,7 @@ http {
         local env_orange_conf = os.getenv("ORANGE_CONF")
         print(string.char(27) .. "[34m" .. "[INFO]" .. string.char(27).. "[0m", [[the env[ORANGE_CONF] is ]], env_orange_conf)
 
-        local config_file = env_orange_conf or "./conf/orange.conf"
+        local config_file = env_orange_conf or ngx.config.prefix().. "/conf/orange.conf"
         local config, store = orange.init({
             config = config_file
         })
@@ -73,12 +73,6 @@ http {
         location = /favicon.ico {
             log_not_found off;
             access_log off;
-        }
-
-        location /gateway_benchmark {
-            content_by_lua_block{
-                ngx.say('work good');
-            }
         }
 
         location / {

--- a/orange/plugins/signature_auth/handler.lua
+++ b/orange/plugins/signature_auth/handler.lua
@@ -114,16 +114,16 @@ local function filter_rules(sid, plugin, ngx_var_uri)
 end
 
 
-local BasicAuthHandler = BasePlugin:extend()
-BasicAuthHandler.PRIORITY = 2000
+local SignatureAuthHandler = BasePlugin:extend()
+SignatureAuthHandler.PRIORITY = 2000
 
-function BasicAuthHandler:new(store)
-    BasicAuthHandler.super.new(self, "signature_auth-plugin")
+function SignatureAuthHandler:new(store)
+    SignatureAuthHandler.super.new(self, "signature_auth-plugin")
     self.store = store
 end
 
-function BasicAuthHandler:access(conf)
-    BasicAuthHandler.super.access(self)
+function SignatureAuthHandler:access(conf)
+    SignatureAuthHandler.super.access(self)
 
     local enable = orange_db.get("signature_auth.enable")
     local meta = orange_db.get_json("signature_auth.meta")
@@ -173,4 +173,4 @@ function BasicAuthHandler:access(conf)
 
 end
 
-return BasicAuthHandler
+return SignatureAuthHandler

--- a/otherAuto.Makefile
+++ b/otherAuto.Makefile
@@ -1,0 +1,7 @@
+systemtap:
+    wrk -c 10 -d30s -t2 "http://127.0.0.1?usr=111&pwd=111&sig=1111" &
+    sudo ngx-sample-lua-bt -p `cat logs/nginx.pid ` --luajit20 -t 5  > tmp.bt
+    fix-lua-bt tmp.bt > a.bt
+    stackcollapse-stap.pl a.bt > a.cbt
+    flamegraph.pl a.cbt > a.svg
+

--- a/otherAuto.Makefile
+++ b/otherAuto.Makefile
@@ -1,5 +1,7 @@
+URL ?= 'http://127.0.0.1?usr=111&pwd=111&sig=1111'
+
 systemtap:
-    wrk -c 10 -d30s -t2 "http://127.0.0.1?usr=111&pwd=111&sig=1111" &
+    wrk -c 10 -d30s -t2  $(URL)&
     sudo ngx-sample-lua-bt -p `cat logs/nginx.pid ` --luajit20 -t 5  > tmp.bt
     fix-lua-bt tmp.bt > a.bt
     stackcollapse-stap.pl a.bt > a.cbt


### PR DESCRIPTION
1. 使用 `server prefix`获取   配置文件
2. 日志格式修改，https跟upstream相关的信息添加入日志。
3. 纠正插件名字。这些名字在火焰图中会出现，否则看起来令人疑惑。
4. 添加一个makefile ，把一些自动化的工作放进去，既是文档，又是代码 :),，还可以直接运行。好事。。。

------


1. get config file by `server prefix`  
2. change logformat , add https upstream info to log
3. correct plugins name ,or may be  not clearly in systemtap picture
4. add another makefile ,to do some automate things.