### PR TITLE
fix: invalid replacement value

### DIFF
--- a/orange/utils/handle.lua
+++ b/orange/utils/handle.lua
@@ -16,6 +16,10 @@ local function compose(extractor_type, tmpl, variables)
     if not extractor_type or extractor_type == 1 then
         -- replace with ngx.re.gsub
         local result = string_gsub(tmpl, "%${([1-9]+)}", function(m)
+            if type(variables[tonumber(m)]) ~= "string" then
+                return tmpl
+            end
+
             return variables[tonumber(m)]
         end)
 
@@ -28,7 +32,7 @@ end
 local _M = {}
 
 ---
--- @param extractor_type number, the extractor type 
+-- @param extractor_type number, the extractor type
 -- @param url_tmpl string
 --  extractor_type==1 then url template, contains variable placeholder ${number}, e.g. /user/${1}/friends/${2}
 --  extractor_type==2 then url template, contains variable placeholder {{key.[subkey]}}, e.g. /user/{{host}}/friends/{{header.uid}}
@@ -39,7 +43,7 @@ function _M.build_url(extractor_type, url_tmpl, variables)
 end
 
 ---
--- @param extractor_type number, the extractor type 
+-- @param extractor_type number, the extractor type
 -- @param uri_tmpl string
 --  extractor_type==1 then url template, contains variable placeholder ${number}, e.g. /user/${1}/friends/${2}
 --  extractor_type==2 then url template, contains variable placeholder {{key.[subkey]}}, e.g. /user/{{host}}/friends/{{header.uid}}


### PR DESCRIPTION
#### desc: 

`ngx.req.get_uri_args` Arguments without the =<value> parts are treated as boolean arguments

if use `variable extract ` It was submitted to a null value, like this:
```
curl $host/$uri?string=1       #: ok
curl $host/$uri?string       #: problem
```

