### PR TITLE
uniform json function call and fix jit-uuid no call seed

### DIFF
--- a/orange/lib/globalpatches.lua
+++ b/orange/lib/globalpatches.lua
@@ -7,13 +7,13 @@ return function(opts)
 
     -- Add a special randomseed for math, no arguments
     do
-        local util = require "orange.utils.utils"
+        local utils = require "orange.utils.utils"
         local randomseed = math.randomseed
         local seed
 
         _G.math.randomseed = function()
             if not seed then
-                seed = util.get_random_seed()
+                seed = utils.get_random_seed()
             else
                 ngx.log(ngx.ERR, "The seed random number generator seed has already seeded with: " .. seed .. "\n")
             end

--- a/orange/lib/json_decoder.lua
+++ b/orange/lib/json_decoder.lua
@@ -1,0 +1,440 @@
+-- Helper wrappring script for loading shared object libac.so (FFI interface)
+-- from package.cpath instead of LD_LIBRARTY_PATH.
+--
+
+local ffi = require 'ffi'
+ffi.cdef[[
+typedef enum {
+    OT_INT64,
+    OT_FP,
+    OT_STR,
+    OT_BOOL,
+    OT_NULL,
+    OT_LAST_PRIMITIVE = OT_NULL,
+    OT_HASHTAB,
+    OT_ARRAY,
+    OT_ROOT /* type of dummy object introduced during parsing process */
+} obj_ty_t;
+
+struct obj_tag;
+typedef struct obj_tag obj_t;
+
+struct obj_tag {
+    obj_t* next;
+    int32_t obj_ty;
+    union {
+        int32_t str_len;
+        int32_t elmt_num; /* # of element of array/hashtab */
+    };
+};
+
+/* primitive object */
+typedef struct {
+    obj_t common;
+    union {
+        char* str_val;
+        int64_t int_val;
+        double db_val;
+    };
+} obj_primitive_t;
+
+struct obj_composite_tag;
+typedef struct obj_composite_tag obj_composite_t;
+struct obj_composite_tag {
+    obj_t common;
+    obj_t* subobjs;
+    obj_composite_t* reverse_nesting_order;
+    uint32_t id;
+};
+
+struct json_parser;
+
+/* Export functions */
+struct json_parser* jp_create(void);
+obj_t* jp_parse(struct json_parser*, const char* json, uint32_t len);
+const char* jp_get_err(struct json_parser*);
+void jp_destroy(struct json_parser*);
+]]
+
+local cobj_ptr_t = ffi.typeof("obj_composite_t*")
+local pobj_ptr_t = ffi.typeof("obj_primitive_t*")
+local obj_ptr_t = ffi.typeof("obj_t*")
+
+local ffi_cast = ffi.cast
+local ffi_string = ffi.string
+
+local _M = {}
+local ok, tab_new = pcall(require, "table.new")
+if not ok then
+    tab_new = function (narr, nrec) return {} end
+end
+
+local jp_lib
+
+--[[ Find shared object file package.cpath, obviating the need of setting
+   LD_LIBRARY_PATH
+]]
+local function find_shared_obj(cpath, so_name)
+    local string_gmatch = string.gmatch
+    local string_match = string.match
+    local io_open = io.open
+
+    for k in string_gmatch(cpath, "[^;]+") do
+        local so_path = string_match(k, "(.*/)")
+        so_path = so_path .. so_name
+
+        -- Don't get me wrong, the only way to know if a file exist is trying
+        -- to open it.
+        local f = io_open(so_path)
+        if f ~= nil then
+            io.close(f)
+            return so_path
+        end
+    end
+end
+
+local function load_json_parser()
+    if jp_lib ~= nil then
+        return jp_lib
+    else
+        local so_path = find_shared_obj(package.cpath, "libljson.so")
+        if so_path ~= nil then
+            jp_lib = ffi.load(so_path)
+            return jp_lib
+        end
+    end
+end
+
+function _M.create()
+end
+
+local ty_int64 = 0
+local ty_fp = 1
+local ty_str = 2
+local ty_bool = 3
+local ty_null = 4
+local ty_last_primitive = 4
+local ty_hashtab = 5
+local ty_array= 6
+
+local create_primitive
+local create_array
+local create_hashtab
+local convert_obj
+local tonumber = tonumber
+
+create_primitive = function(obj)
+    local ty = obj.common.obj_ty
+    if ty == ty_int64 then
+        return tonumber(obj.int_val)
+    elseif ty == ty_str then
+        return ffi_string(obj.str_val, obj.common.str_len)
+    elseif ty == ty_null then
+        return nil
+    elseif ty == ty_bool then
+        if obj.int_val == 0 then
+            return false
+        else
+            return true
+        end
+    else
+        return tonumber(obj.db_val)
+    end
+
+    return nil, "Unknown primitive type"
+end
+
+create_array = function(array, cobj_array)
+    local elmt_num = array.common.elmt_num
+    local elmt_list = array.subobjs
+
+    -- HINT: The representation of an array-obj [e1, e2,..., en]
+    --   is en->...->e2->e1
+    local result = tab_new(elmt_num, 0)
+    for iter = 1, elmt_num do
+        local elmt = elmt_list
+
+        local elmt_obj
+        if elmt.obj_ty <= ty_last_primitive then
+            local err;
+            elmt_obj, err = create_primitive(ffi_cast(pobj_ptr_t, elmt))
+            if err then
+                return nil, err
+            end
+        else
+            local cobj = ffi_cast(cobj_ptr_t, elmt);
+            elmt_obj = cobj_array[cobj.id + 1]
+        end
+
+        result[elmt_num - iter + 1] = elmt_obj
+        elmt_list = elmt_list.next
+    end
+
+    cobj_array[array.id + 1] = result
+
+    return result;
+end
+
+create_hashtab = function(hashtab, cobj_array)
+    local elmt_num = hashtab.common.elmt_num
+    local elmt_list = hashtab.subobjs
+
+    -- HINT: The representation of a hash-obj {k1,v1,...,kn:vn}
+    --   is vn->kn->...->v1->k1.
+    local result = tab_new(0, elmt_num / 2)
+    for _ = 1, elmt_num, 2 do
+        local val = elmt_list
+        elmt_list = elmt_list.next
+
+        local key = ffi_cast(pobj_ptr_t, elmt_list)
+        local key_obj = ffi_string(key.str_val, key.common.str_len)
+
+        local val_obj = nil
+        if val.obj_ty <= ty_last_primitive then
+            local err;
+            val_obj, err = create_primitive(ffi_cast(pobj_ptr_t, val))
+            if err then
+                return nil, err
+            end
+        else
+            local cobj = ffi_cast(cobj_ptr_t, val);
+            val_obj = cobj_array[cobj.id + 1]
+        end
+
+        result[key_obj] = val_obj;
+        elmt_list = elmt_list.next
+    end
+
+    cobj_array[hashtab.id + 1] = result
+
+    return result
+end
+
+convert_obj = function(obj, cobj_array)
+    local ty = obj.obj_ty
+    if ty <= ty_last_primitive then
+        return create_primitive(ffi_cast(pobj_ptr_t, obj))
+    elseif ty == ty_array then
+        return create_array(ffi_cast(cobj_ptr_t, obj), cobj_array)
+    else
+        return create_hashtab(ffi_cast(cobj_ptr_t, obj), cobj_array)
+    end
+end
+
+-- Create an array big enough to accommodate elmt_num + 2 elements.
+-- If cobj_vect is big enough, return it; otherwise, create a new one.
+local function create_cobj_vect(cobj_vect, elmt_num)
+    local array_size = elmt_num + 2
+    local cap = cobj_vect[0]
+    if cap < 400 and cap >= array_size then
+        return cobj_vect
+    end
+
+    cobj_vect = tab_new(array_size, 1)
+    cobj_vect[0] = array_size
+    return cobj_vect
+end
+
+-- set each element to be nil, such that they can be GC-ed ASAP.
+local function clean_cobj_vect(cobj_vect, elmt_num)
+    for iter = 1, elmt_num + 2 do
+        cobj_vect[iter] = nil
+    end
+end
+
+-- #########################################################################
+--
+--      "Export" functions
+--
+-- #########################################################################
+local setmetatable = setmetatable
+local mt = { __index = _M }
+
+function _M.new()
+    if not jp_lib then
+        load_json_parser()
+    end
+
+    if not jp_lib then
+        return nil, "fail to load libjson.so"
+    end
+
+    local parser_inst = jp_lib.jp_create()
+    if parser_inst ~= nil then
+        ffi.gc(parser_inst, jp_lib.jp_destroy)
+    else
+        return nil, "Fail to create JSON parser, likely due to OOM"
+    end
+
+    local cobj_vect = tab_new(100, 1)
+    if cobj_vect then
+        cobj_vect[0] = 100
+    else
+        return nil, "fail to create intermediate array"
+    end
+
+    local self = {
+        cobj_vect = cobj_vect,
+        parser = parser_inst
+    }
+
+    return setmetatable(self, mt)
+end
+
+function _M.decode(self, json)
+    --[[
+    if not self then
+        return nil, "JSON parser was not initialized properly"
+    end]]
+
+    local objs = jp_lib.jp_parse(self.parser, json, #json)
+    if objs == nil then
+        return nil, ffi_string(jp_lib.jp_get_err(self.parser))
+    end
+
+    local ty = objs.obj_ty
+    if ty <= ty_last_primitive then
+        return convert_obj(objs)
+    end
+
+    local composite_objs = ffi_cast(cobj_ptr_t, objs)
+    local elmt_num = composite_objs.id
+    local cobj_vect = create_cobj_vect(self.cobj_vect, elmt_num)
+    self.cobj_vect = cobj_vect
+
+    local last_val
+    repeat
+        last_val = convert_obj(ffi_cast(obj_ptr_t, composite_objs), cobj_vect)
+        composite_objs = composite_objs.reverse_nesting_order
+    until composite_objs == nil
+
+    clean_cobj_vect(cobj_vect, elmt_num)
+
+    return last_val
+end
+
+-- return:
+--  1). array of strings in the input JSON
+--  2). error message if error occur
+--
+--  1) could be nil if no string at all is found, if 1) is non-nil
+--     element with index 0 is the size of the array
+--
+function _M.get_strings(self, json)
+
+    -- step 1: decode the input JSON
+    local objs = jp_lib.jp_parse(self.parser, json, #json)
+    if objs == nil then
+        return nil, ffi_string(jp_lib.jp_get_err(self.parser))
+    end
+
+    local ty = objs.obj_ty
+    if ty <= ty_last_primitive then
+        -- The enclosing object must be either a hashtab or array
+        return nil, "malformed JSON"
+    end
+
+    local composite_objs = ffi_cast(cobj_ptr_t, objs)
+    local str_count = 0
+
+    -- step 2: count the number of strings
+    repeat
+        local elmt_num = composite_objs.common.elmt_num
+        local elmt_list = composite_objs.subobjs
+
+        -- go through all element
+        for iter = 1, elmt_num do
+            local elmt = elmt_list
+            elmt_list = elmt_list.next
+
+            if elmt.obj_ty == ty_str then
+                str_count = str_count + 1
+            end
+        end
+        composite_objs = composite_objs.reverse_nesting_order
+    until composite_objs == nil
+
+    if str_count == 0 then
+        return
+    end
+
+    -- step 3: collect all strings
+    local str_array = tab_new(str_count, 1)
+    composite_objs = ffi_cast(cobj_ptr_t, objs)
+    local idx = 1
+
+    repeat
+        local elmt_num = composite_objs.common.elmt_num
+        local elmt_list = composite_objs.subobjs
+
+        -- go through all elements
+        for iter = 1, elmt_num do
+            local elmt = elmt_list
+            elmt_list = elmt_list.next
+
+            if elmt.obj_ty == ty_str then
+                elmt = ffi_cast(pobj_ptr_t, elmt)
+                str_array[idx] = ffi_string(elmt.str_val, elmt.common.str_len)
+                idx = idx + 1
+            end
+        end
+        composite_objs = composite_objs.reverse_nesting_order
+    until composite_objs == nil
+
+    str_array[0] = str_count;
+
+    return str_array
+end
+
+-- #########################################################################
+--
+--      Debugging and Misc
+--
+-- #########################################################################
+local print_primitive
+local print_table
+local print_var
+local print = print
+local string_format = string.format
+local tostring = tostring
+local pairs = pairs
+local type = type
+local io_write = io.write
+
+print_primitive = function(luadata)
+    if type(luadata) == "string" then
+        io_write(string_format("\"%s\"", luadata))
+    else
+        io_write(tostring(luadata))
+    end
+end
+
+print_table = function(array)
+    io_write("{");
+    local elmt_num = 0
+    for k, v in pairs(array) do
+        if elmt_num > 0 then
+            io_write(", ")
+        end
+
+        print_primitive(k)
+        io_write(":")
+        print_var(v)
+        elmt_num = elmt_num + 1
+    end
+    io_write("}");
+end
+print_var = function(var)
+    if type(var) == "table" then
+        print_table(var)
+    else
+        print_primitive(var)
+    end
+end
+
+function _M.debug(luadata)
+    print_var(luadata)
+    print("")
+end
+
+return _M

--- a/orange/orange.lua
+++ b/orange/orange.lua
@@ -5,7 +5,6 @@ local pcall = pcall
 local require = require
 require("orange.lib.globalpatches")()
 local utils = require("orange.utils.utils")
-local uuid = require("orange.lib.jit-uuid")
 local config_loader = require("orange.utils.config_loader")
 local dao = require("orange.store.dao")
 
@@ -85,7 +84,6 @@ end
 
 function Orange.init_worker()
     -- 仅在 init_worker 阶段调用，初始化随机因子，仅允许调用一次
-    uuid.seed()
     math.randomseed()
     -- 初始化定时器，清理计数器等
     if Orange.data and Orange.data.store and Orange.data.config.store == "mysql" then

--- a/orange/orange.lua
+++ b/orange/orange.lua
@@ -5,6 +5,7 @@ local pcall = pcall
 local require = require
 require("orange.lib.globalpatches")()
 local utils = require("orange.utils.utils")
+local uuid = require("orange.lib.jit-uuid")
 local config_loader = require("orange.utils.config_loader")
 local dao = require("orange.store.dao")
 
@@ -84,6 +85,7 @@ end
 
 function Orange.init_worker()
     -- 仅在 init_worker 阶段调用，初始化随机因子，仅允许调用一次
+    uuid.seed()
     math.randomseed()
     -- 初始化定时器，清理计数器等
     if Orange.data and Orange.data.store and Orange.data.config.store == "mysql" then

--- a/orange/plugins/common_api.lua
+++ b/orange/plugins/common_api.lua
@@ -2,7 +2,7 @@ local ipairs = ipairs
 local type = type
 local tostring = tostring
 local table_insert = table.insert
-local cjson = require("cjson")
+local json = require("orange.utils.json")
 local orange_db = require("orange.store.orange_db")
 local utils = require("orange.utils.utils")
 local stringy = require("orange.utils.stringy")
@@ -143,7 +143,7 @@ return function(plugin)
                     })
                 end
 
-                local current_selector = utils.json_decode(selector.value)
+                local current_selector = json.decode(selector.value)
                 if not current_selector then
                     return res:json({
                         success = false,
@@ -152,7 +152,7 @@ return function(plugin)
                 end
 
                 local rule = req.body.rule
-                rule = cjson.decode(rule)
+                rule = json.decode(rule)
                 rule.id = utils.new_id()
                 rule.time = utils.now()
 
@@ -220,7 +220,7 @@ return function(plugin)
             return function(req, res, next)
                 local selector_id = req.params.id
                 local rule = req.body.rule
-                rule = utils.json_decode(rule)
+                rule = json.decode(rule)
                 rule.time = utils.now()
 
                 local update_result = dao.update_rule(plugin, store, rule)
@@ -270,7 +270,7 @@ return function(plugin)
                     })
                 end
 
-                local current_selector = utils.json_decode(selector.value)
+                local current_selector = json.decode(selector.value)
                 if not current_selector then
                     return res:json({
                         success = false,
@@ -373,7 +373,7 @@ return function(plugin)
                         msg = "error to find selector when resorting rules of it"
                     })
                 else
-                    local new_selector = utils.json_decode(selector.value) or {}
+                    local new_selector = json.decode(selector.value) or {}
                     new_selector.rules = rules
                     update_selector_result = dao.update_selector(plugin, store, new_selector)
                     if update_selector_result then
@@ -439,7 +439,7 @@ return function(plugin)
                 end
 
                 -- delete rules of it
-                local to_del_selector = utils.json_decode(selector.value)
+                local to_del_selector = json.decode(selector.value)
                 if not to_del_selector then
                     return res:json({
                         success = false,
@@ -453,7 +453,7 @@ return function(plugin)
 
                 -- update meta
                 local meta = dao.get_meta(plugin, store)
-                local current_meta = utils.json_decode(meta.value)
+                local current_meta = json.decode(meta.value)
                 if not meta or not current_meta then
                    return res:json({
                         success = false,
@@ -508,7 +508,7 @@ return function(plugin)
         POST = function(store) -- create a selector
             return function(req, res)
                 local selector = req.body.selector
-                selector = cjson.decode(selector)
+                selector = json.decode(selector)
                 selector.id = utils.new_id()
                 selector.time = utils.now()
 
@@ -517,7 +517,7 @@ return function(plugin)
 
                 -- update meta
                 local meta = dao.get_meta(plugin, store)
-                local current_meta = utils.json_decode(meta and meta.value or "{}")
+                local current_meta = json.decode(meta and meta.value or "{}")
                 if not meta or not current_meta then
                    return res:json({
                         success = false,
@@ -562,7 +562,7 @@ return function(plugin)
         PUT = function(store) -- update
             return function(req, res, next)
                 local selector = req.body.selector
-                selector = cjson.decode(selector)
+                selector = json.decode(selector)
                 selector.time = utils.now()
                 -- 更新selector
                 local update_selector_result = dao.update_selector(plugin, store, selector)
@@ -618,7 +618,7 @@ return function(plugin)
                         msg = "error to find meta when resorting selectors"
                     })
                 else
-                    local new_meta = utils.json_decode(meta.value) or {}
+                    local new_meta = json.decode(meta.value) or {}
                     new_meta.selectors = selectors
                     update_meta_result = dao.update_meta(plugin, store, new_meta)
                     if update_meta_result then

--- a/orange/plugins/property_rate_limiting/counter.lua
+++ b/orange/plugins/property_rate_limiting/counter.lua
@@ -1,5 +1,5 @@
-local cjson = require("cjson")
 local resty_lock = require("resty.lock")
+local json = require("orange.utils.json")
 local plugin_config =  require("orange.plugins.property_rate_limiting.plugin")
 
 local ngx_log = ngx.log
@@ -27,7 +27,7 @@ end
 function _M.get_json(key)
     local value, f = _M.get(key)
     if value then
-        value = cjson.decode(value)
+        value = json.decode(value)
     end
 
     return value, f
@@ -35,7 +35,7 @@ end
 
 function _M.set_json(key, value, expired)
     if value then
-        value = cjson.encode(value)
+        value = json.encode(value)
     end
 
     return _M.set(key, value, expired)

--- a/orange/plugins/rate_limiting/counter.lua
+++ b/orange/plugins/rate_limiting/counter.lua
@@ -1,4 +1,4 @@
-local cjson = require("cjson")
+local json = require("orange.utils.json")
 local resty_lock = require("resty.lock")
 local ngx_log = ngx.log
 local cache = ngx.shared.rate_limit
@@ -25,7 +25,7 @@ end
 function _M.get_json(key)
     local value, f = _M.get(key)
     if value then
-        value = cjson.decode(value)
+        value = json.decode(value)
     end
 
     return value, f
@@ -33,7 +33,7 @@ end
 
 function _M.set_json(key, value, expired)
     if value then
-        value = cjson.encode(value)
+        value = json.encode(value)
     end
 
     return _M.set(key, value, expired)

--- a/orange/store/dao.lua
+++ b/orange/store/dao.lua
@@ -3,7 +3,7 @@ local table_insert = table.insert
 local table_concat = table.concat
 local type = type
 local xpcall = xpcall
-local cjson = require("cjson")
+local json = require("orange.utils.json")
 local utils = require("orange.utils.utils")
 local orange_db = require("orange.store.orange_db")
 
@@ -13,7 +13,7 @@ local _M = {
 }
 
 function _M.get_selector(plugin, store, selector_id)
-    if not selector_id or selector_id == "" or type(selector_id) ~= "string" then 
+    if not selector_id or selector_id == "" or type(selector_id) ~= "string" then
         return nil
     end
 
@@ -30,7 +30,7 @@ function _M.get_selector(plugin, store, selector_id)
 end
 
 function _M.get_rules_of_selector(plugin, store, rule_ids)
-    if not rule_ids or type(rule_ids) ~= "table" or #rule_ids == 0 then 
+    if not rule_ids or type(rule_ids) ~= "table" or #rule_ids == 0 then
         return {}
     end
 
@@ -58,7 +58,7 @@ function _M.get_rules_of_selector(plugin, store, rule_ids)
         -- reorder the rules as the order stored in selector
         for _, rule_id in ipairs(rule_ids) do
             for _, r in ipairs(rules) do
-                local tmp = utils.json_decode(r.value)
+                local tmp = json.decode(r.value)
                 if tmp and tmp.id == rule_id then
                     table_insert(format_rules, tmp)
                 end
@@ -71,7 +71,7 @@ function _M.get_rules_of_selector(plugin, store, rule_ids)
 end
 
 function _M.delete_rules_of_selector(plugin, store, rule_ids)
-    if not rule_ids or rule_ids == "" or type(rule_ids) ~= "table" then 
+    if not rule_ids or rule_ids == "" or type(rule_ids) ~= "table" then
         return true
     end
 
@@ -97,7 +97,7 @@ function _M.delete_rules_of_selector(plugin, store, rule_ids)
 end
 
 function _M.delete_selector(plugin, store, selector_id)
-    if not selector_id or selector_id == "" or type(selector_id) ~= "string" then 
+    if not selector_id or selector_id == "" or type(selector_id) ~= "string" then
         return true
     end
 
@@ -128,11 +128,11 @@ function _M.get_meta(plugin, store)
 end
 
 function _M.update_meta(plugin, store, meta)
-    if not meta or type(meta) ~= "table" then 
+    if not meta or type(meta) ~= "table" then
         return false
     end
 
-    local meta_json_str = utils.json_encode(meta)
+    local meta_json_str = json.encode(meta)
     if not meta_json_str then
         ngx.log(ngx.ERR, "encode error: meta to save is not json format.")
         return false
@@ -147,11 +147,11 @@ function _M.update_meta(plugin, store, meta)
 end
 
 function _M.update_selector(plugin, store, selector)
-    if not selector or type(selector) ~= "table" then 
+    if not selector or type(selector) ~= "table" then
         return false
     end
 
-    local selector_json_str = utils.json_encode(selector)
+    local selector_json_str = json.encode(selector)
     if not selector_json_str then
         ngx.log(ngx.ERR, "encode error: selector to save is not json format.")
         return false
@@ -203,7 +203,7 @@ function _M.update_local_selectors(plugin, store)
     local to_update_selectors = {}
     if selectors and type(selectors) == "table" then
         for _, s in ipairs(selectors) do
-            to_update_selectors[s.key] = utils.json_decode(s.value or "{}")
+            to_update_selectors[s.key] = json.decode(s.value or "{}")
         end
 
         local success, err, forcible = orange_db.set_json(plugin .. ".selectors", to_update_selectors)
@@ -235,7 +235,7 @@ function _M.update_local_selector_rules(plugin, store, selector_id)
         return false
     end
 
-    selector = utils.json_decode(selector.value)
+    selector = json.decode(selector.value)
     local rules_ids = selector.rules or {}
     local rules = _M.get_rules_of_selector(plugin, store, rules_ids)
 
@@ -244,28 +244,28 @@ function _M.update_local_selector_rules(plugin, store, selector_id)
         ngx.log(ngx.ERR, "update local rules of selector error, err:", err)
         return false
     end
-    
+
     return true
 end
 
 function _M.create_selector(plugin, store, selector)
     return store:insert({
         sql = "insert into " .. plugin .. "(`key`, `value`, `type`, `op_time`) values(?,?,?,?)",
-        params = { selector.id, cjson.encode(selector), "selector", selector.time }
+        params = { selector.id, json.encode(selector), "selector", selector.time }
     })
 end
 
 function _M.update_rule(plugin, store, rule)
     return store:update({
         sql = "update " .. plugin .. " set `value`=?,`op_time`=? where `key`=? and `type`=?",
-        params = { cjson.encode(rule), rule.time, rule.id, "rule" }
+        params = { json.encode(rule), rule.time, rule.id, "rule" }
     })
 end
 
 function _M.create_rule(plugin, store, rule)
     return store:insert({
         sql = "insert into " .. plugin .. "(`key`, `value`, `op_time`, `type`) values(?,?,?,?)",
-        params = { rule.id, utils.json_encode(rule), rule.time, "rule" }
+        params = { rule.id, json.encode(rule), rule.time, "rule" }
     })
 end
 
@@ -297,7 +297,7 @@ function _M.init_rules_of_selector(plugin, store, selector_id)
         return false
     end
 
-    selector = utils.json_decode(selector.value)
+    selector = json.decode(selector.value)
     local rules_ids = selector.rules or {}
     local rules = _M.get_rules_of_selector(plugin, store, rules_ids)
 
@@ -306,7 +306,7 @@ function _M.init_rules_of_selector(plugin, store, selector_id)
         ngx.log(ngx.ERR, "init plugin[" .. plugin .. "] local rules of selector error, err:", err)
         return false
     end
-    
+
     return true
 end
 
@@ -369,7 +369,7 @@ function _M.init_selectors_of_plugin(plugin, store)
     local to_update_selectors = {}
     if selectors and type(selectors) == "table" then
         for _, s in ipairs(selectors) do
-            to_update_selectors[s.key] = utils.json_decode(s.value or "{}")
+            to_update_selectors[s.key] = json.decode(s.value or "{}")
 
             -- init this selector's rules local cache
             local init_rules_of_it = _M.init_rules_of_selector(plugin, store, s.key)
@@ -401,7 +401,7 @@ end
 function _M.compose_plugin_data(store, plugin)
     local data = {}
     local ok, e
-    ok = xpcall(function() 
+    ok = xpcall(function()
         -- get enable
         local enables, err = store:query({
             sql = "select `key`, `value` from meta where `key`=?",
@@ -431,7 +431,7 @@ function _M.compose_plugin_data(store, plugin)
         end
 
         if meta and type(meta) == "table" and #meta > 0 then
-            data[plugin .. ".meta"] = utils.json_decode(meta[1].value) or {}
+            data[plugin .. ".meta"] = json.decode(meta[1].value) or {}
         else
             ngx.log(ngx.ERR, "can not find meta from storage when fetching data of plugin[" .. plugin .. "]")
             return false
@@ -451,7 +451,7 @@ function _M.compose_plugin_data(store, plugin)
         local to_update_selectors = {}
         if selectors and type(selectors) == "table" then
             for _, s in ipairs(selectors) do
-                to_update_selectors[s.key] = utils.json_decode(s.value or "{}")
+                to_update_selectors[s.key] = json.decode(s.value or "{}")
 
                 -- init this selector's rules local cache
                 local selector_id = s.key
@@ -466,7 +466,7 @@ function _M.compose_plugin_data(store, plugin)
                     return false
                 end
 
-                selector = utils.json_decode(selector.value)
+                selector = json.decode(selector.value)
                 local rules_ids = selector.rules or {}
                 local rules = _M.get_rules_of_selector(plugin, store, rules_ids)
                 data[plugin .. ".selector." .. selector_id .. ".rules"] = rules
@@ -494,7 +494,7 @@ end
 -- ########################### init cache when starting orange #############################
 function _M.load_data_by_mysql(store, plugin)
     local ok, e
-    ok = xpcall(function() 
+    ok = xpcall(function()
         local v = plugin
         if not v or v == "" then
             ngx.log(ngx.ERR, "params error, the `plugin` is nil")

--- a/orange/store/dao.lua
+++ b/orange/store/dao.lua
@@ -4,7 +4,6 @@ local table_concat = table.concat
 local type = type
 local xpcall = xpcall
 local json = require("orange.utils.json")
-local utils = require("orange.utils.utils")
 local orange_db = require("orange.store.orange_db")
 
 

--- a/orange/store/orange_db.lua
+++ b/orange/store/orange_db.lua
@@ -1,4 +1,4 @@
-local cjson = require("cjson")
+local json = require("orange.utils.json")
 local orange_data = ngx.shared.orange_data
 
 
@@ -11,7 +11,7 @@ end
 function _M.get_json(key)
     local value, f = _M._get(key)
     if value then
-        value = cjson.decode(value)
+        value = json.decode(value)
     end
     return value, f
 end
@@ -26,7 +26,7 @@ end
 
 function _M.set_json(key, value)
     if value then
-        value = cjson.encode(value)
+        value = json.encode(value)
     end
     return _M._set(key, value)
 end

--- a/orange/utils/condition.lua
+++ b/orange/utils/condition.lua
@@ -1,4 +1,5 @@
 local type = type
+local tostring = tostring
 local string_format = string.format
 local string_find = string.find
 local string_lower = string.lower
@@ -124,7 +125,7 @@ function _M.judge(condition)
         real =  ngx.var.host
     end
 
-    return assert_condition(real, operator, expected)
+    return assert_condition(tostring(real), operator, expected)
 end
 
 

--- a/orange/utils/config_loader.lua
+++ b/orange/utils/config_loader.lua
@@ -1,5 +1,5 @@
-local cjson = require("cjson")
 local IO = require("orange.utils.io")
+local json = require("orange.utils.json")
 
 local _M = {}
 
@@ -12,7 +12,7 @@ function _M.load(config_path)
         os.exit(1)
     end
 
-    local config = cjson.decode(config_contents)
+    local config = json.decode(config_contents)
     return config, config_path
 end
 

--- a/orange/utils/json.lua
+++ b/orange/utils/json.lua
@@ -1,0 +1,36 @@
+local cjson = require("cjson.safe")
+local ljson_decoder = require("orange.lib.json_decoder")
+
+local _M = {
+    json_decoder = ljson_decoder.new()
+}
+
+
+function _M.encode(data, empty_table_as_object)
+    if not data then return nil end
+
+    if cjson.encode_empty_table_as_object then
+        -- empty table default is arrya
+        cjson.encode_empty_table_as_object(empty_table_as_object or false)
+    end
+
+    if require("ffi").os ~= "Windows" then
+        cjson.encode_sparse_array(true)
+    end
+
+    return cjson.encode(data)
+end
+
+
+function _M.decode(data)
+    if not data then return nil end
+
+    if not _M.json_decoder then
+        return cjson.decode(data)
+    end
+
+    return _M.json_decoder:decode(data)
+end
+
+
+return _M

--- a/orange/utils/json.lua
+++ b/orange/utils/json.lua
@@ -1,9 +1,4 @@
 local cjson = require("cjson.safe")
-local ljson_decoder = require("orange.lib.json_decoder")
-
-local _M = {
-    json_decoder = ljson_decoder.new()
-}
 
 
 function _M.encode(data, empty_table_as_object)
@@ -25,11 +20,7 @@ end
 function _M.decode(data)
     if not data then return nil end
 
-    if not _M.json_decoder then
-        return cjson.decode(data)
-    end
-
-    return _M.json_decoder:decode(data)
+    return cjson.decode(data)
 end
 
 

--- a/orange/utils/utils.lua
+++ b/orange/utils/utils.lua
@@ -3,7 +3,6 @@
 local require = require
 local uuid = require("orange.lib.jit-uuid")
 local date = require("orange.lib.date")
-local json = require("cjson")
 local type = type
 local pcall = pcall
 local pairs = pairs
@@ -101,31 +100,6 @@ end
 
 function _M.new_id()
     return uuid()
-end
-
-function _M.json_encode(data, empty_table_as_object)
-    if not data then return nil end
-
-    local json_value
-    if json.encode_empty_table_as_object then
-        json.encode_empty_table_as_object(empty_table_as_object or false) -- 空的table默认为array
-    end
-    if require("ffi").os ~= "Windows" then
-        json.encode_sparse_array(true)
-    end
-
-    pcall(function(d) json_value = json.encode(d) end, data)
-    return json_value
-end
-
-function _M.json_decode(str)
-    if not str then return nil end
-    local json_object
-    pcall(function(data)
-        json_object = json.decode(data)
-    end, str)
-
-    return json_object
 end
 
 --- Calculates a table size.

--- a/orange/utils/utils.lua
+++ b/orange/utils/utils.lua
@@ -99,7 +99,6 @@ function _M.random_string()
 end
 
 function _M.new_id()
-    uuid.seed()
     return uuid()
 end
 

--- a/orange/utils/utils.lua
+++ b/orange/utils/utils.lua
@@ -99,6 +99,7 @@ function _M.random_string()
 end
 
 function _M.new_id()
+    uuid.seed()
     return uuid()
 end
 


### PR DESCRIPTION
#### case 1
submit `a5449f0e82258cac5bd812c0edf3bd243a862ded` and `1e576b0b6a305ed8eda224bfdee6a4e04f498b48`  for json function call uniform

I added support for lua-resty-json, and it does not matter if there is no dylibs

#### case 2 (`I tested no problem in centos`)
submit `ba682c8fad7f1eec08e135f86e81b93591e44ee3`  to solve the primary key duplication systems appear on mac 

error msg:
```
Duplicate entry '2e41eb51-145a-4b06-adbe-8d1e22087fb0' for key 'unique_key
```

source by [lua-resty-jit-uuid](https://github.com/thibaultcha/lua-resty-jit-uuid)
```
http {
    init_worker_by_lua_block {
        local uuid = require 'resty.jit-uuid'
        uuid.seed() -- very important!
    }

    server {
        location / {
            content_by_lua_block {
                local uuid = require 'resty.jit-uuid'
                ngx.say(uuid())
            }
        }
    }
}
```

