### PR TITLE
refact: nginx.conf. To solve requesty body in temp file not supported

### DIFF
--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -27,6 +27,14 @@ http {
         server localhost:8001;
     }
 
+    #
+    # Config client_body_buffer_size equal client_max_body_size for enforcing in-memory buffering of the whole request body
+    # ref: https://github.com/openresty/lua-nginx-module/issues/521
+    #
+    # official instruct docs http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    #
+    client_body_buffer_size 1m;
+    client_max_body_size 1m;
 
     #----------------------------Orange configuration-----------------------------
     lua_package_path '../?.lua;/usr/local/lor/?.lua;;';


### PR DESCRIPTION
To solve requesty body in temp file not supported
the buffer size using the default value `1m` 

http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size

ref docs: https://github.com/openresty/lua-nginx-module/issues/521