### PR TITLE
fix bug - invalid URL prefix in ""

### DIFF
--- a/orange/plugins/balancer/handler.lua
+++ b/orange/plugins/balancer/handler.lua
@@ -15,8 +15,8 @@ local function now()
 end
 
 local BalancerHandler = BasePlugin:extend()
--- set balancer priority to 1000 so that balancer's access will be called at last
-BalancerHandler.PRIORITY = 1000
+-- set balancer priority to 999 so that balancer's access will be called at last
+BalancerHandler.PRIORITY = 999
 
 function BalancerHandler:new(store)
     BalancerHandler.super.new(self, "Balancer-plugin")
@@ -31,6 +31,7 @@ function BalancerHandler:access(conf)
     local selectors = orange_db.get_json("balancer.selectors")
 
     if not enable or enable ~= true or not meta or not selectors then
+        ngx.var.target = ngx.var.upstream_url
         return
     end
     


### PR DESCRIPTION
最开始写的时候没有给balancer开关，所以target一上来就会设置为ngx.var.upstream_url

后来加上了开关，当开关未打开的时候，target的值没有赋值，导致出现 invalid URL prefix in "" 错误

该 Patch 解决了这个问题

为了保证balancer的access最后执行，将balancer的插件级别设置为999

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>