### PR TITLE
Alter selector continue behavior

### DIFF
--- a/orange/plugins/basic_auth/handler.lua
+++ b/orange/plugins/basic_auth/handler.lua
@@ -104,6 +104,7 @@ function BasicAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -116,15 +117,8 @@ function BasicAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "basic_auth", ngx_var_uri, authorization)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/basic_auth/handler.lua
+++ b/orange/plugins/basic_auth/handler.lua
@@ -104,7 +104,6 @@ function BasicAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -117,6 +116,7 @@ function BasicAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "basic_auth", ngx_var_uri, authorization)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/basic_auth/handler.lua
+++ b/orange/plugins/basic_auth/handler.lua
@@ -119,17 +119,17 @@ function BasicAuthHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[BasicAuth][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/divide/handler.lua
+++ b/orange/plugins/divide/handler.lua
@@ -109,17 +109,17 @@ function DivideHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[Divide][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/divide/handler.lua
+++ b/orange/plugins/divide/handler.lua
@@ -94,7 +94,6 @@ function DivideHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -107,6 +106,7 @@ function DivideHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "divide", ngx_var, ngx_var_uri, ngx_var_host)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/divide/handler.lua
+++ b/orange/plugins/divide/handler.lua
@@ -94,6 +94,7 @@ function DivideHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -106,15 +107,8 @@ function DivideHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "divide", ngx_var, ngx_var_uri, ngx_var_host)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/key_auth/handler.lua
+++ b/orange/plugins/key_auth/handler.lua
@@ -158,6 +158,7 @@ function KeyAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -170,15 +171,8 @@ function KeyAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "key_auth", ngx_var_uri, headers, body, query)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/key_auth/handler.lua
+++ b/orange/plugins/key_auth/handler.lua
@@ -173,17 +173,17 @@ function KeyAuthHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[KeyAuth][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/key_auth/handler.lua
+++ b/orange/plugins/key_auth/handler.lua
@@ -158,7 +158,6 @@ function KeyAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -171,6 +170,7 @@ function KeyAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "key_auth", ngx_var_uri, headers, body, query)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/monitor/handler.lua
+++ b/orange/plugins/monitor/handler.lua
@@ -66,7 +66,6 @@ function URLMonitorHandler:log(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -79,6 +78,7 @@ function URLMonitorHandler:log(conf)
                 end
 
                 local stop = filter_rules(sid, "monitor", ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/monitor/handler.lua
+++ b/orange/plugins/monitor/handler.lua
@@ -66,6 +66,7 @@ function URLMonitorHandler:log(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -78,15 +79,8 @@ function URLMonitorHandler:log(conf)
                 end
 
                 local stop = filter_rules(sid, "monitor", ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/monitor/handler.lua
+++ b/orange/plugins/monitor/handler.lua
@@ -81,17 +81,17 @@ function URLMonitorHandler:log(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[Monitor][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/property_rate_limiting/handler.lua
+++ b/orange/plugins/property_rate_limiting/handler.lua
@@ -128,17 +128,17 @@ function PropertyRateLimitingHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[",plugin_config.name_for_log,"][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/property_rate_limiting/handler.lua
+++ b/orange/plugins/property_rate_limiting/handler.lua
@@ -113,6 +113,7 @@ function PropertyRateLimitingHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -125,15 +126,8 @@ function PropertyRateLimitingHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, plugin_config.table_name, ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/property_rate_limiting/handler.lua
+++ b/orange/plugins/property_rate_limiting/handler.lua
@@ -113,7 +113,6 @@ function PropertyRateLimitingHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -126,6 +125,7 @@ function PropertyRateLimitingHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, plugin_config.table_name, ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/rate_limiting/handler.lua
+++ b/orange/plugins/rate_limiting/handler.lua
@@ -110,7 +110,6 @@ function RateLimitingHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -123,6 +122,7 @@ function RateLimitingHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "rate_limiting", ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/rate_limiting/handler.lua
+++ b/orange/plugins/rate_limiting/handler.lua
@@ -125,17 +125,17 @@ function RateLimitingHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[RateLimiting][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/rate_limiting/handler.lua
+++ b/orange/plugins/rate_limiting/handler.lua
@@ -110,6 +110,7 @@ function RateLimitingHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -122,15 +123,8 @@ function RateLimitingHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "rate_limiting", ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/redirect/handler.lua
+++ b/orange/plugins/redirect/handler.lua
@@ -96,6 +96,7 @@ function RedirectHandler:redirect()
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -108,15 +109,8 @@ function RedirectHandler:redirect()
                 end
 
                 local stop = filter_rules(sid, "redirect", ngx_var_uri, ngx_var_host, ngx_var_scheme, ngx_var_args)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/redirect/handler.lua
+++ b/orange/plugins/redirect/handler.lua
@@ -111,17 +111,17 @@ function RedirectHandler:redirect()
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[Redirect][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/redirect/handler.lua
+++ b/orange/plugins/redirect/handler.lua
@@ -96,7 +96,6 @@ function RedirectHandler:redirect()
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass 
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -109,6 +108,7 @@ function RedirectHandler:redirect()
                 end
 
                 local stop = filter_rules(sid, "redirect", ngx_var_uri, ngx_var_host, ngx_var_scheme, ngx_var_args)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/rewrite/handler.lua
+++ b/orange/plugins/rewrite/handler.lua
@@ -83,6 +83,7 @@ function RewriteHandler:rewrite(conf)
     for i, sid in ipairs(ordered_selectors) do
         ngx.log(ngx.INFO, "==[Rewrite][PASS THROUGH SELECTOR:", sid, "]")
         local selector = selectors[sid]
+        local selector_continue = selector.handle and selector.handle.continue
         if selector and selector.enable == true then
             local selector_pass 
             if selector.type == 0 then -- 全流量选择器
@@ -97,15 +98,8 @@ function RewriteHandler:rewrite(conf)
                 end
 
                 local stop = filter_rules(sid, "rewrite", ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/rewrite/handler.lua
+++ b/orange/plugins/rewrite/handler.lua
@@ -100,17 +100,17 @@ function RewriteHandler:rewrite(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[Rewrite][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/rewrite/handler.lua
+++ b/orange/plugins/rewrite/handler.lua
@@ -83,7 +83,6 @@ function RewriteHandler:rewrite(conf)
     for i, sid in ipairs(ordered_selectors) do
         ngx.log(ngx.INFO, "==[Rewrite][PASS THROUGH SELECTOR:", sid, "]")
         local selector = selectors[sid]
-        local selector_continue = selector.handle and selector.handle.continue
         if selector and selector.enable == true then
             local selector_pass 
             if selector.type == 0 then -- 全流量选择器
@@ -98,6 +97,7 @@ function RewriteHandler:rewrite(conf)
                 end
 
                 local stop = filter_rules(sid, "rewrite", ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/signature_auth/handler.lua
+++ b/orange/plugins/signature_auth/handler.lua
@@ -141,6 +141,7 @@ function SignatureAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -153,15 +154,8 @@ function SignatureAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "signature_auth", ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/signature_auth/handler.lua
+++ b/orange/plugins/signature_auth/handler.lua
@@ -141,7 +141,6 @@ function SignatureAuthHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -154,6 +153,7 @@ function SignatureAuthHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "signature_auth", ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/signature_auth/handler.lua
+++ b/orange/plugins/signature_auth/handler.lua
@@ -156,17 +156,17 @@ function SignatureAuthHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[SignatureAuth][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end

--- a/orange/plugins/waf/handler.lua
+++ b/orange/plugins/waf/handler.lua
@@ -75,7 +75,6 @@ function WAFHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
-            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -88,6 +87,7 @@ function WAFHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "waf", ngx_var_uri)
+                local selector_continue = selector.handle and selector.handle.continue
                 if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
                 end

--- a/orange/plugins/waf/handler.lua
+++ b/orange/plugins/waf/handler.lua
@@ -75,6 +75,7 @@ function WAFHandler:access(conf)
         local selector = selectors[sid]
         if selector and selector.enable == true then
             local selector_pass
+            local selector_continue = selector.handle and selector.handle.continue
             if selector.type == 0 then -- 全流量选择器
                 selector_pass = true
             else
@@ -87,15 +88,8 @@ function WAFHandler:access(conf)
                 end
 
                 local stop = filter_rules(sid, "waf", ngx_var_uri)
-                if stop then -- 不再执行此插件其他逻辑
+                if stop or not selector_continue then -- 不再执行此插件其他逻辑
                     return
-                end
-
-                -- if continue or break the loop
-                if selector.handle and selector.handle.continue == true then
-                    -- continue next selector
-                else
-                    break
                 end
             else
                 if selector.handle and selector.handle.log == true then

--- a/orange/plugins/waf/handler.lua
+++ b/orange/plugins/waf/handler.lua
@@ -90,17 +90,17 @@ function WAFHandler:access(conf)
                 if stop then -- 不再执行此插件其他逻辑
                     return
                 end
+
+                -- if continue or break the loop
+                if selector.handle and selector.handle.continue == true then
+                    -- continue next selector
+                else
+                    break
+                end
             else
                 if selector.handle and selector.handle.log == true then
                     ngx.log(ngx.INFO, "[WAF][NOT-PASS-SELECTOR:", sid, "] ", ngx_var_uri)
                 end
-            end
-
-            -- if continue or break the loop
-            if selector.handle and selector.handle.continue == true then
-                -- continue next selector
-            else
-                break
             end
         end
     end


### PR DESCRIPTION
If the selector type is 1(i.e. self define flow), and continue = false,
we should only stop excuting other selectors when the judge_selector
returns true.

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>