### PR TITLE
使用正确的read timeout 参数。

### DIFF
--- a/orange/plugins/balancer/handler.lua
+++ b/orange/plugins/balancer/handler.lua
@@ -34,7 +34,7 @@ function BalancerHandler:access(conf)
         ngx.var.target = ngx.var.upstream_url
         return
     end
-    
+
     local upstream_url = ngx.var.upstream_url
     ngx.log(ngx.INFO, "[upstream_url] ", upstream_url)
 
@@ -77,7 +77,7 @@ function BalancerHandler:access(conf)
                         retries            = upstream.retries or 0, -- number of retries for the balancer
                         connection_timeout = upstream.connection_timeout or 60000,
                         send_timeout       = upstream.send_timeout or 60000,
-                        read_timeout       = upstream_read_timeout or 60000,
+                        read_timeout       = upstream.read_timeout or 60000,
 
                         -- ip              = nil,     -- final target IP address
                         -- balancer        = nil,     -- the balancer object, in case of balancer
@@ -132,7 +132,7 @@ function BalancerHandler:balancer(conf)
 
         local ok, err = balancer_execute(addr)
         if not ok then
-            ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ", 
+            ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ",
                     addr.host, "' with: ", tostring(err))
             return ngx.exit(500)
         end

--- a/orange/plugins/balancer/handler.lua
+++ b/orange/plugins/balancer/handler.lua
@@ -34,7 +34,6 @@ function BalancerHandler:access(conf)
         ngx.var.target = ngx.var.upstream_url
         return
     end
-
     local upstream_url = ngx.var.upstream_url
     ngx.log(ngx.INFO, "[upstream_url] ", upstream_url)
 

--- a/orange/plugins/balancer/handler.lua
+++ b/orange/plugins/balancer/handler.lua
@@ -131,7 +131,7 @@ function BalancerHandler:balancer(conf)
 
         local ok, err = balancer_execute(addr)
         if not ok then
-            ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ",
+            ngx.log(ngx.ERR, "failed to retry the dns/balancer resolver for ", 
                     addr.host, "' with: ", tostring(err))
             return ngx.exit(500)
         end


### PR DESCRIPTION
作者，你好。修改了一下proxy_read_timeout参数的获取方式：
通过upstream.read_timeout来获取正确的参数：read_timeout 而不是：upstream_read_timeout。