### PR TITLE
统一使用Obejct作为基类，并且__call用于创建实例，new用于构建实例属性

### DIFF
--- a/conf/orange.conf.example
+++ b/conf/orange.conf.example
@@ -24,6 +24,7 @@
             "database": "orange",
             "user": "root",
             "password": "",
+            "charset": "utf8",
             "max_packet_size": 1048576
         },
         "pool_config": {

--- a/orange/store/mysql_db.lua
+++ b/orange/store/mysql_db.lua
@@ -5,15 +5,13 @@ local setmetatable = setmetatable
 local ngx_quote_sql_str = ngx.quote_sql_str
 local mysql = require("resty.mysql")
 local utils = require("orange.utils.utils")
+local Object = require("orange.lib.classic")
 
 
-local DB = {}
+local DB = Object:extend()
 
 function DB:new(conf)
-    local instance = {}
-    instance.conf = conf
-    setmetatable(instance, { __index = self})
-    return instance
+    self.conf = conf
 end
 
 function DB:exec(sql)
@@ -33,7 +31,6 @@ function DB:exec(sql)
 
     ngx.log(ngx.INFO, "connected to mysql, reused_times:", db:get_reused_times(), " sql:", sql)
 
-    db:query("SET NAMES utf8")
     local res, err, errno, sqlstate = db:query(sql)
     if not res or err then
         ngx.log(ngx.ERR, "bad result: ", err, ": ", errno, ": ", sqlstate, ".")

--- a/orange/store/mysql_store.lua
+++ b/orange/store/mysql_store.lua
@@ -5,13 +5,13 @@ local Store = require("orange.store.base")
 local MySQLStore = Store:extend()
 
 function MySQLStore:new(options)
-    self._name = options.name or "mysql-store"
-    MySQLStore.super.new(self, self._name)
+    local name = options.name or "mysql-store"
+    self.super.new(self, name)
     self.store_type = "mysql"
     local connect_config = options.connect_config
     self.mysql_addr = connect_config.host .. ":" .. connect_config.port
     self.data = {}
-    self.db = mysql_db:new(options)
+    self.db = mysql_db(options)
 end
 
 function MySQLStore:query(opts)


### PR DESCRIPTION
统一使用Obejct作为基类，方法__call用于创建实例，new用于构建实例属性
在mysql连接时设置好charset，不多分出一个query来设置