### PR TITLE
Import opm and luarocks tools and complete README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,37 @@ A Gateway based on OpenResty(Nginx+lua) for API Monitoring and Management.
     - Orange v0.6.2+ is compatible with lor v0.3.0+
 
 Import the SQL file(e.g. install/orange-v0.7.0.sql) which is adapted to your Orange version into MySQL database named `orange`.
+- Install luarocks and opm tools
+    - The Version of luarocks is higher than LuaRocks 2.2.2
+    - Opm tool is integrated in Openresty, it is under the openresty/bin directory
 
-#### Install
 
-1) dependencies
+#### Install and Config
+
+1) Install dependencies
 
 ```bash
-# cd orange          // Go to the Orange directory
-# make dependencies  // Installation dependent extension
+#cd orange         // Go to the Orange directory
+#opm --install-dir=./ get zhangbao0325/orangelib      //opm download the 3rd packages
+#luarocks install luafilesystem         //luarocks install lua dependencies             
+#luarocks install luasocket
 ```
 
-2) script management
+2) Generate configuration file
+```bash
+#cd conf
+#cp orange.conf.example orange.conf
+#cp nginx.conf.example nginx.conf
+```
+Attention:    
+ - the directive "store_mysql" in orange.conf should be modified as your mysql configuration,
+ - the directiv  "lua_package_path" should add your lua package installation path of luarocks tool;    
+
+3) script management
 
 use shell scripts (e.g. `start.sh`) to manage Orange.
 
-3) CLI tools
+4) CLI tools
 
 In addition to `start.sh` script, a new cli tool could be utilized to manage Orange. You should install the cli first:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,12 +23,10 @@ Orange是一个基于OpenResty的API网关。除Nginx的基本功能外，它还
     - 若使用的Orange版本高于或等于v0.6.2则应安装lor v0.3.0+版本
 - MySQL
     - 配置存储和集群扩展需要MySQL支持
-- 使用luarocks安装一些第三方库
-    - luarocks install https://luarocks.org/manifests/steved/penlight-1.5.4-1.rockspec
-    - luarocks install https://luarocks.org/manifests/kong/lua-resty-dns-client-2.2.0-1.rockspec
-    - luarocks install https://luarocks.org/lua-resty-http-0.13-0.src.rock
-    - luarocks install https://luarocks.org/manifests/luarocks/luasocket-3.0rc1-2.rockspec
-
+- 安装luarocks和opm包管理工具
+    - luarocks安装LuaRocks 2.2.2+以上版本。
+    - 若使用openresty,自身集成opm工具，在openresty/bin目录下。
+     
 #### 数据表导入MySQL
 
 - 在MySQL中创建数据库，名为orange
@@ -93,18 +91,34 @@ conf/nginx.conf里是一些nginx相关配置，请自行检查并按照实际需
 - 各个server或是location的权限，如是否需要通过`allow/deny`指定配置黑白名单ip
 
 
-#### 安装
+#### 安装与配置
 
-1) 依赖安装
+1) 安装依赖包
+```
+    cd orange
+    luarocks install luafilesystem
+    luarocks install luasocket
+   
+    opm --install-dir=./ get zhangbao0325/orangelib        
+```
 
-可以通过`make dependencies`将Orange依赖的扩展库安装到系统中。
+2) 修改配置文件
+```angular2html
+    cd conf
+    cp orange.conf.example orange.conf
+    cp nginx.conf.example nginx.conf
+    
+```
+其中，orange.conf中数据库store_mysql配置请修改成你安装好的数据库。
+nginx.conf中lua_package_path添加上你的luarocks的lua包安装路径。
 
-2) 脚本管理工具
+
+3) 脚本管理工具
 
 无需安装, 只要将Orange下载下来, 根据需要修改一下`orange.conf`和`nginx.conf`配置，然后使用`start.sh`脚本即可启动。
 默认提供的nginx.conf和start.sh都是最简单的配置，只是给用户一个默认的配置参考，用户应该根据实际生产要求自行添加或更改其中的配置以满足需要。
 
-3) 命令行管理工具
+4) 命令行管理工具
 
 可以通过`make install`将Orange安装到系统中(默认安装到/usr/local/orange)。 执行此命令后， 以下两部分将被安装：
 

--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -42,7 +42,7 @@ http {
     client_max_body_size 1m;
 
     #----------------------------Orange configuration-----------------------------
-    lua_package_path '../?.lua;/usr/local/lor/?.lua;;';
+    lua_package_path './lualib/?.lua;./lualib/resty/?.lua;../?.lua;/usr/local/lor/?.lua;;';
     lua_code_cache on;
 
     lua_shared_dict orange_data 20m; # should not removed. used for orange data, e.g. plugins configurations..
@@ -62,6 +62,7 @@ http {
         local env_orange_conf = os.getenv("ORANGE_CONF")
         print(string.char(27) .. "[34m" .. "[INFO]" .. string.char(27).. "[0m", [[the env[ORANGE_CONF] is ]], env_orange_conf)
 
+        # Here, you can also use the absolute path, eg: local confige_file = "/home/openresty/orange/conf/orange.conf"
         local config_file = env_orange_conf or ngx.config.prefix().. "/conf/orange.conf"
         local config, store = orange.init({
             config = config_file


### PR DESCRIPTION
通过opm和luarocks工具，将orange依赖的第三方库进行打包，省去了用户自己下载、安装、配置依赖项的操作，让用户能快速启动项目。